### PR TITLE
Improve task install

### DIFF
--- a/.github/actions/setup-validation/action.yml
+++ b/.github/actions/setup-validation/action.yml
@@ -21,9 +21,8 @@ runs:
   using: "composite"
   steps:
     - name: Task installation
-      uses: arduino/setup-task@v1
-      with:
-        version: 3.x
+      shell: bash
+      run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
     - name: PHP installation
       uses: shivammathur/setup-php@v2

--- a/.github/actions/setup-website/action.yml
+++ b/.github/actions/setup-website/action.yml
@@ -10,6 +10,7 @@ runs:
         mkdir -p ./web/sites/default
         cp ./.github/actions/setup-website/.env ./.env
         cp ./.github/actions/setup-website/docker-compose.yml ./docker-compose.yml
+        cp ./.github/actions/setup-website/php.dockerfile ./php.dockerfile
 
     - name: Build PHP container
       shell: bash

--- a/.github/actions/setup-website/action.yml
+++ b/.github/actions/setup-website/action.yml
@@ -13,15 +13,11 @@ runs:
 
     - name: Build PHP container
       shell: bash
-      run: docker compose up -d --no-deps --build php
+      run: docker compose build php
 
     - name: Run docker
       shell: bash
       run: docker compose up -d
-
-    - name: Install Task into docker
-      shell: bash
-      run: docker compose exec -T php sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
     - name: Install site
       shell: bash

--- a/.github/actions/setup-website/docker-compose.yml
+++ b/.github/actions/setup-website/docker-compose.yml
@@ -2,7 +2,12 @@ version: "3.7"
 
 services:
   php:
-    image: wodby/drupal-php:$PHP_TAG
+    image: ${PROJECT_NAME}/php:$PHP_TAG
+    build:
+      context: .
+      dockerfile: php.dockerfile
+      args:
+        PHP_TAG: $PHP_TAG
     container_name: "${PROJECT_NAME}_php"
     # This fixed permissions issues caused in GitHub Actions.
     # GHA has UID 1001, but D4D uses 1000. It results that d4d containers can't write anything to cloned files.

--- a/.github/actions/setup-website/php.dockerfile
+++ b/.github/actions/setup-website/php.dockerfile
@@ -1,0 +1,5 @@
+ARG PHP_TAG
+FROM wodby/drupal-php:${PHP_TAG}
+
+USER wodby
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin

--- a/config/cspell/dictionary.txt
+++ b/config/cspell/dictionary.txt
@@ -16,6 +16,7 @@ prismjs
 Rcmjg
 sfmono
 SSMTP
+Taskfile
 teck
 testdox
 Tinkoff


### PR DESCRIPTION
Task tool installation using `arduino/setup-task` often falls into API limitations.